### PR TITLE
bump: version v0.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,37 +14,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
-            
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
     steps:
       - name: Check out git repository
         uses: actions/checkout@v3.0.0
-      
+
       - name: Install Node.js
         uses: actions/setup-node@v3.0.0
         with:
           node-version: "18.12.0"
-          
+
       - name: Install Dependencies
         run: npm install
-        
+
       - name: Build Electron App
         run: npm run dist
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-    
+
       - name: Cleanup Artifacts for Windows
         if: matrix.os == 'windows-latest'
         run: |
-          npx rimraf "dist/!(*.exe)"
-      
+          npx rimraf "release/**/!(*.exe|*.zip|*.nsis. seventies)"
+          mv release/**/Helium*.exe release/Helium-${{ github.ref_name }}-windows.exe
+          mv release/**/Helium*.zip release/Helium-${{ github.ref_name }}-windows.zip
+          mv release/**/Helium*.nsis.7z release/Helium-${{ github.ref_name }}-windows-portable.nsis.7z
+
+
+      - name: Cleanup Artifacts for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          npx rimraf "release/**/!(*.AppImage|*.deb)"
+          mv release/**/Helium*.AppImage release/Helium-${{ github.ref_name }}-linux.AppImage
+          mv release/**/Helium*.deb release/Helium-${{ github.ref_name }}-linux.deb
+
       - name: Cleanup Artifacts for MacOS
         if: matrix.os == 'macos-latest'
         run: |
-          npx rimraf "dist/!(*.dmg)"
+          npx rimraf "release/**/!(*.dmg|*.zip)"
+          mv release/**/Helium*.dmg release/Helium-${{ github.ref_name }}-macos.dmg
+          mv release/**/Helium*.zip release/Helium-${{ github.ref_name }}-macos.zip
           
       - name: upload artifacts
         uses: actions/upload-artifact@v3.0.0
         with:
           name: ${{ matrix.os }}
-          path: dist
+          path: release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heliummusic",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "background.js",
   "author": "mtrstatic",
   "scripts": {
@@ -55,7 +55,11 @@
       "allowToChangeInstallationDirectory": true
     },
     "mac": {
-      "category": ""
+      "category": "",
+      "target": [
+        "dmg",
+        "zip"
+      ]
     },
     "win": {
       "icon": "./src/assets/icon/icon.ico",
@@ -66,7 +70,12 @@
       ],
       "verifyUpdateCodeSignature": false
     },
-    "linux": {},
+    "linux": {
+      "target": [
+        "AppImage",
+        "deb"
+      ]
+    },
     "publish": [
       {
         "provider": "github",

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,2 +1,0 @@
-name: Helium Music
-title: Arknights-style 3rd party music player, powered by NetEase Cloud Music API and build with VuePress & Electron


### PR DESCRIPTION
Configure multi-platform builds, remove Snapcraft, and bump version to 0.4.1

- Updated electron-builder configuration in package.json for explicit Windows, Linux (AppImage, deb), and macOS (dmg, zip) targets.
- Deleted snapcraft.yaml to prevent Snap package builds.
- Modified .github/workflows/build.yml to build on Windows, Linux, and macOS.
- Adjusted artifact cleanup and renaming steps in the GitHub Actions workflow.
- Updated application version from 0.4.0 to 0.4.1 in package.json.